### PR TITLE
feat: ダウンロード元特定を強化してクリック元と揃える

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -79,8 +79,12 @@
               </div>
               <div class="mb-2" id="site-pattern-container" style="display: none">
                 <label class="form-label small mb-1">対象サイトのURL/ドメイン</label>
-                <input type="text" class="form-control form-control-sm" id="rule-site-pattern"
-                  placeholder="例: teams.microsoft.com" />
+                <div class="input-group input-group-sm">
+                  <input type="text" class="form-control form-control-sm" id="rule-site-pattern"
+                    placeholder="例: teams.microsoft.com" />
+                  <button class="btn btn-secondary" type="button" id="get-current-site-button"
+                    title="現在のサイトを取得">現在のサイト</button>
+                </div>
               </div>
               <div class="mb-2">
                 <label class="form-label small mb-1">条件</label>

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,81 +1,25 @@
+import { downloadPathRouter } from "./background/index";
 import { reloadExtension } from "../scripts/reload";
-import { Rule, Settings } from "./settings";
+import { reloadTargetTabs } from "./utils/reload-tabs";
+
+const targetUrls: string[] = ["https://www.google.com/*", "https://github.com/*"];
+
+/** 開発環境の場合，拡張機能をリロード */
+function developExtension(env: string | undefined): void {
+  if (env === "development") {
+    console.log("開発環境：", env);
+    console.log("ターゲットタブのリロードを開始します", targetUrls);
+    reloadExtension();
+    reloadTargetTabs(targetUrls);
+  }
+}
 
 /**
  * Background Script を初期化
  */
 function initialize(): void {
-  console.log("現在の環境：", process.env.NODE_ENV);
-
-  if (process.env.NODE_ENV === "development") {
-    reloadExtension();
-  }
-
-  // ダウンロード時の名前確定イベントを監視
-  chrome.downloads.onDeterminingFilename.addListener((item, suggest) => {
-    chrome.storage.local.get(["settings", "enabled"], (data) => {
-      const enabled = data.enabled !== false; // デフォルトは有効
-      if (!enabled) {
-        suggest();
-        return;
-      }
-
-      const settings: Settings = data.settings || { rules: [] };
-      const rules: Rule[] = settings.rules || [];
-
-      // サイト別ルールを優先するためにソート（site が先，general が後）
-      // 同じカテゴリ内では登録順（あるいは後で登録したものを優先するなら逆順）
-      const sortedRules = [...rules].sort((a, b) => {
-        if (a.category === "site" && b.category === "general") return -1;
-        if (a.category === "general" && b.category === "site") return 1;
-        return 0;
-      });
-
-      for (const rule of sortedRules) {
-        let match = false;
-
-        // サイト別ルールのサイト判定（sitePatternがある場合）
-        if (rule.category === "site" && rule.sitePattern) {
-          if (!item.url.toLowerCase().includes(rule.sitePattern.toLowerCase())) {
-            continue; // サイトがマッチしない場合は次のルールへ
-          }
-        }
-
-        const pattern = rule.pattern.toLowerCase();
-        if (rule.condition === "extension") {
-          // 拡張子チェック (例: .pdf)
-          const extension = item.filename.split(".").pop()?.toLowerCase() || "";
-          match = extension === pattern.replace(/^\./, "");
-        } else if (rule.condition === "filename") {
-          // ファイル名チェック (部分一致)
-          match = item.filename.toLowerCase().includes(pattern);
-        } else if (rule.condition === "url") {
-          // URLチェック (部分一致)
-          match = item.url.toLowerCase().includes(pattern);
-        }
-
-        if (match) {
-          // フォルダ名がある場合は，フォルダ名/ファイル名 として提案
-          // フォルダ名の末尾の / は除去して結合
-          const folder = rule.folder.replace(/\/$/, "");
-          const finalFilename = folder ? `${folder}/${item.filename}` : item.filename;
-
-          suggest({
-            filename: finalFilename,
-            conflictAction: "uniquify",
-          });
-          console.log(`Matched rule: ${rule.id}, moving to: ${finalFilename}`);
-          return;
-        }
-      }
-
-      // マッチするルールがない場合はそのまま
-      suggest();
-    });
-
-    // 非同期で suggest を呼び出すために true を返す
-    return true;
-  });
+  developExtension(process.env.NODE_ENV);
+  downloadPathRouter();
 }
 
 initialize();

--- a/src/background/click-history.ts
+++ b/src/background/click-history.ts
@@ -1,0 +1,46 @@
+/**
+ * クリック履歴管理
+ */
+
+export interface ClickHistory {
+  pageUrl: string;
+  timestamp: number;
+}
+
+const histories: ClickHistory[] = [];
+const MAX_HISTORY = 50;
+const HISTORY_TIMEOUT = 30000; // 30秒
+
+/**
+ * クリック履歴に記録
+ */
+export function recordClick(pageUrl: string, timestamp: number): void {
+  histories.unshift({ pageUrl, timestamp });
+  if (histories.length > MAX_HISTORY) {
+    histories.pop();
+  }
+}
+
+/**
+ * 古い履歴をクリーンアップ
+ */
+export function cleanup(): void {
+  const now = Date.now();
+  const valid = histories.filter(h => (now - h.timestamp) < HISTORY_TIMEOUT);
+  histories.length = 0;
+  histories.push(...valid);
+}
+
+/**
+ * 履歴を取得
+ */
+export function getHistories(): ClickHistory[] {
+  return histories;
+}
+
+/**
+ * 履歴数を取得
+ */
+export function getCount(): number {
+  return histories.length;
+}

--- a/src/background/domain.ts
+++ b/src/background/domain.ts
@@ -1,0 +1,36 @@
+/**
+ * ドメイン処理ユーティリティ
+ */
+
+/**
+ * URLからフルドメインを抽出
+ * @param url URL文字列
+ * @returns フルドメイン（例：docs.google.com）
+ */
+export function extractDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * URLから親ドメインを抽出
+ * @param url URL文字列
+ * @returns 親ドメイン（例：docs.google.com → google.com）
+ */
+export function extractParentDomain(url: string): string | null {
+  const domain = extractDomain(url);
+  if (!domain) return null;
+
+  const parts = domain.split('.');
+
+  // ローカルホストやIPは特別扱い
+  if (parts.length <= 2 || domain === 'localhost') {
+    return domain;
+  }
+
+  // 最後の2つを取得（TLD + ドメイン）
+  return parts.slice(-2).join('.');
+}

--- a/src/background/download-matcher.ts
+++ b/src/background/download-matcher.ts
@@ -1,0 +1,76 @@
+/**
+ * ダウンロードのページURL特定ロジック
+ */
+
+import { extractDomain, extractParentDomain } from './domain';
+import { getHistories } from './click-history';
+
+/**
+ * ダウンロード時のページURLを特定
+ * @param downloadUrl ダウンロード元URL
+ * @returns マッチしたページURL，またはnull
+ */
+export function findPageUrl(downloadUrl: string): string | null {
+  const downloadDomain = extractDomain(downloadUrl);
+  const downloadParentDomain = extractParentDomain(downloadUrl);
+
+  if (!downloadParentDomain) {
+    return getRecentFallback();
+  }
+
+  // 1. 親ドメイン一致を優先
+  const parentMatch = findByParentDomain(downloadParentDomain);
+  if (parentMatch) {
+    return parentMatch;
+  }
+
+  // 2. 完全なドメイン一致
+  if (downloadDomain) {
+    const exactMatch = findByExactDomain(downloadDomain);
+    if (exactMatch) {
+      return exactMatch;
+    }
+  }
+
+  // 3. 最新のクリック履歴をフォールバック
+  return getRecentFallback();
+}
+
+/**
+ * 親ドメインが一致するクリック履歴を検索
+ */
+function findByParentDomain(parentDomain: string): string | null {
+  const match = getHistories().find(h => {
+    const pageParent = extractParentDomain(h.pageUrl);
+    return pageParent === parentDomain;
+  });
+  return match?.pageUrl || null;
+}
+
+/**
+ * ドメインが完全一致するクリック履歴を検索
+ */
+function findByExactDomain(domain: string): string | null {
+  const match = getHistories().find(h => {
+    const pageDomain = extractDomain(h.pageUrl);
+    return pageDomain === domain;
+  });
+  return match?.pageUrl || null;
+}
+
+/**
+ * 最新のクリック履歴（10秒以内）をフォールバック
+ */
+function getRecentFallback(): string | null {
+  const histories = getHistories();
+  if (histories.length === 0) return null;
+
+  const now = Date.now();
+  const recent = histories[0];
+
+  if ((now - recent.timestamp) < 10000) {
+    return recent.pageUrl;
+  }
+
+  return null;
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,0 +1,109 @@
+import { Rule, Settings } from "../settings";
+import { recordClick, cleanup } from "./click-history";
+import { findPageUrl } from "./download-matcher";
+
+// ダウンロードIDとページURLのマッピング
+const downloadPageUrlMap = new Map<number, string>();
+
+/** ファイルのダウンロードパスをルーティング */
+export function downloadPathRouter(): void {
+
+  // Content Script からのクリック通知を受信
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'PAGE_CLICK') {
+      recordClick(message.pageUrl, message.timestamp);
+    }
+  });
+
+  // ダウンロード開始時にページURLを特定
+  chrome.downloads.onCreated.addListener((downloadItem) => {
+    cleanup();
+    const pageUrl = findPageUrl(downloadItem.url);
+
+    if (pageUrl) {
+      downloadPageUrlMap.set(downloadItem.id, pageUrl);
+      console.log(`ダウンロード: ID=${downloadItem.id} → ${pageUrl}`);
+    }
+  });
+
+  // ダウンロード完了/中断時にクリーンアップ
+  chrome.downloads.onChanged.addListener((delta) => {
+    if (delta.state?.current === 'complete' || delta.state?.current === 'interrupted') {
+      downloadPageUrlMap.delete(delta.id);
+    }
+  });
+
+  // ダウンロード時の名前確定イベント
+  chrome.downloads.onDeterminingFilename.addListener((item, suggest) => {
+    handleDeterminingFilename(item, suggest);
+    return true;
+  });
+}
+
+/**
+ * ダウンロードファイル名決定処理
+ */
+function handleDeterminingFilename(item: chrome.downloads.DownloadItem, suggest: (suggestion?: chrome.downloads.FilenameSuggestion) => void): void {
+  chrome.storage.local.get(["settings", "enabled"], (data) => {
+    const enabled = data.enabled !== false;
+    if (!enabled) {
+      suggest();
+      return;
+    }
+
+    const settings: Settings = data.settings || { rules: [] };
+    const rules: Rule[] = settings.rules || [];
+
+    // サイト別ルールを優先
+    const sortedRules = [...rules].sort((a, b) => {
+      if (a.category === "site" && b.category === "general") return -1;
+      if (a.category === "general" && b.category === "site") return 1;
+      return 0;
+    });
+
+    const pageUrl = downloadPageUrlMap.get(item.id) || null;
+
+    // ルールを順に確認
+    for (const rule of sortedRules) {
+      const matchedFolder = matchRule(rule, item, pageUrl);
+      if (matchedFolder) {
+        const finalFilename = matchedFolder ? `${matchedFolder}/${item.filename}` : item.filename;
+        suggest({ filename: finalFilename, conflictAction: "uniquify" });
+        console.log(`ルール適用: ${rule.id} → ${finalFilename}`);
+        return;
+      }
+    }
+
+    // ルール不一致はそのまま
+    suggest();
+  });
+}
+
+/**
+ * ルール判定
+ */
+function matchRule(rule: Rule, item: chrome.downloads.DownloadItem, pageUrl: string | null): string | null {
+  // サイト別ルールのサイト判定
+  if (rule.category === "site" && rule.sitePattern) {
+    const downloadUrlMatch = item.url.toLowerCase().includes(rule.sitePattern.toLowerCase());
+    const pageUrlMatch = pageUrl?.toLowerCase().includes(rule.sitePattern.toLowerCase());
+    if (!downloadUrlMatch && !pageUrlMatch) {
+      return null;
+    }
+  }
+
+  // 条件判定（拡張子、ファイル名、URL）
+  const pattern = rule.pattern.toLowerCase();
+  let matched = false;
+
+  if (rule.condition === "extension") {
+    const extension = item.filename.split(".").pop()?.toLowerCase() || "";
+    matched = extension === pattern.replace(/^\./, "");
+  } else if (rule.condition === "filename") {
+    matched = item.filename.toLowerCase().includes(pattern);
+  } else if (rule.condition === "url") {
+    matched = item.url.toLowerCase().includes(pattern);
+  }
+
+  return matched ? rule.folder.replace(/\/$/, "") : null;
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,1 +1,11 @@
-console.log("content script");
+// ページ内のインタラクションをbackgroundに通知する
+function recordPageInteraction() {
+  chrome.runtime.sendMessage({
+    type: 'PAGE_CLICK',
+    pageUrl: window.location.href,
+    timestamp: Date.now()
+  });
+}
+
+// クリック直前の状態
+document.addEventListener('mousedown', recordPageInteraction, true);

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -89,6 +89,36 @@ class PopupManager {
         sitePatternContainer.style.display = categorySelect.value === 'site' ? 'block' : 'none';
       });
     }
+
+    // 現在のサイトを取得するボタン
+    const getCurrentSiteButton = document.getElementById('get-current-site-button');
+    if (getCurrentSiteButton) {
+      getCurrentSiteButton.addEventListener('click', () => this.fillCurrentSiteUrl());
+    }
+  }
+
+  private fillCurrentSiteUrl(): void {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs.length > 0 && tabs[0].url) {
+        const url = tabs[0].url;
+        // URLからドメイン部分を抽出
+        try {
+          const urlObj = new URL(url);
+          const domain = urlObj.hostname; // www なしのドメインを取得
+          const sitePatternInput = document.getElementById('rule-site-pattern') as HTMLInputElement;
+          if (sitePatternInput) {
+            sitePatternInput.value = domain;
+          }
+        } catch (error) {
+          // console.error('URL parsing error:', error);
+          // URLのパース失敗時は全URLを入力
+          const sitePatternInput = document.getElementById('rule-site-pattern') as HTMLInputElement;
+          if (sitePatternInput) {
+            sitePatternInput.value = url;
+          }
+        }
+      }
+    });
   }
 
   private handleAddOrUpdateRule(): void {


### PR DESCRIPTION
ダウンロード開始時のURL特定処理を強化し，クリック元ページとダウンロードURLの齟齬が起きにくいようにする
クリック履歴と親ドメインを優先して突き合わせる処理を整理