### PR TITLE
fix(manifest): 'tabs' を 'activeTab' に変更し，現在サイト取得に対応

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,12 +42,12 @@ module.exports = {
             to: "./",
             transform(content, absoluteFrom) {
               if (isDev) return content;
-              // production ビルド時に manifest.json から "tabs" パーミッションを削除
+              // production ビルド時に manifest.json の "tabs"を "activeTab" に置き換え
               if (absoluteFrom.endsWith('manifest.json')) {
                 const manifest = JSON.parse(content.toString());
 
                 if (Array.isArray(manifest.permissions)) {
-                  manifest.permissions = manifest.permissions.filter(p => p !== 'tabs');
+                  manifest.permissions = manifest.permissions.map(p => p === 'tabs' ? 'activeTab' : p);
                 }
 
                 const updated = JSON.stringify(manifest, null, 2);


### PR DESCRIPTION
Fixes #3

開発時は `tabs` 権限を使用していたが，production ビルド時に除外していたため現在のサイト取得が機能しなくなっていた．
`tabs` を残すよりも `activeTab` へ置き換えることで必要最小限の権限にした．
