### PR TITLE
feat(priority): ルール優先度のソート機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "chrome-webstore-upload-cli": "^3.5.0",
         "css-loader": "^7.1.2",
         "dotenv": "^17.2.3",
+        "sortablejs": "^1.15.6",
         "style-loader": "^4.0.0"
       },
       "devDependencies": {
         "@types/archiver": "^7.0.0",
         "@types/chrome": "^0.1.6",
+        "@types/sortablejs": "^1.15.9",
         "copy-webpack-plugin": "^13.0.1",
         "cross-env": "^10.1.0",
         "ts-loader": "^9.5.4",
@@ -207,6 +209,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+      "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -2140,6 +2149,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/archiver": "^7.0.0",
     "@types/chrome": "^0.1.6",
+    "@types/sortablejs": "^1.15.9",
     "copy-webpack-plugin": "^13.0.1",
     "cross-env": "^10.1.0",
     "ts-loader": "^9.5.4",
@@ -30,6 +31,7 @@
     "chrome-webstore-upload-cli": "^3.5.0",
     "css-loader": "^7.1.2",
     "dotenv": "^17.2.3",
+    "sortablejs": "^1.15.6",
     "style-loader": "^4.0.0"
   }
 }

--- a/public/popup.css
+++ b/public/popup.css
@@ -21,3 +21,25 @@ html {
 #panel.no-transition {
   transition: none !important;
 }
+
+/* Sortable.js styles */
+.drag-handle {
+  display: none;
+}
+
+.sort-mode-active .drag-handle {
+  display: block;
+}
+
+.sortable-ghost {
+  opacity: 0.4;
+  background: #f8f9fa;
+}
+
+.sortable-chosen {
+  background: #e9ecef;
+}
+
+.sortable-drag {
+  opacity: 1;
+}

--- a/public/popup.html
+++ b/public/popup.html
@@ -143,14 +143,24 @@
       </div>
 
       <!-- サイト別ルールリスト -->
-      <h6 class="mt-4 mb-2">サイト別ルール</h6>
+      <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+        <h6 class="mb-0">サイト別ルール</h6>
+        <button class="btn btn-outline-secondary btn-sm" id="toggle-site-sort-mode" title="並び替えモード">
+          <i class="bi bi-arrow-down-up"></i> 並び替え
+        </button>
+      </div>
       <div id="site-rules-list" class="list-group mb-4">
         <!-- ここにJavaScriptでルールが追加されます -->
         <div class="text-muted small text-center p-2 border rounded">登録されたルールはありません</div>
       </div>
 
       <!-- 通常ルールリスト -->
-      <h6 class="mt-4 mb-2">通常ルール</h6>
+      <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+        <h6 class="mb-0">通常ルール</h6>
+        <button class="btn btn-outline-secondary btn-sm" id="toggle-general-sort-mode" title="並び替えモード">
+          <i class="bi bi-arrow-down-up"></i> 並び替え
+        </button>
+      </div>
       <div id="general-rules-list" class="list-group mb-4">
         <!-- ここにJavaScriptでルールが追加されます -->
         <div class="text-muted small text-center p-2 border rounded">登録されたルールはありません</div>

--- a/src/background.dev.ts
+++ b/src/background.dev.ts
@@ -3,7 +3,7 @@ import { reloadTargetTabs } from "./utils/reload-tabs";
 import { reloadExtension } from "../scripts/reload";
 
 // 開発用のターゲットURLパターン
-const targetUrls: string[] = ["https://www.google.com/*", "https://github.com/*"];
+const targetUrls: string[] = ["https://www.google.com/*", "https://github.com/*", "https://docs.google.com/*"];
 
 if (process.env.NODE_ENV === "development") {
   console.log("開発環境：", process.env.NODE_ENV);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -79,11 +79,16 @@ function handleDeterminingFilename(item: chrome.downloads.DownloadItem, suggest:
     const settings: Settings = data.settings || { rules: [] };
     const rules: Rule[] = settings.rules || [];
 
-    // サイト別ルールを優先
+    // サイト別ルールを優先し，同カテゴリ内では優先度でソート
     const sortedRules = [...rules].sort((a, b) => {
+      // まずカテゴリで分類（サイト別 > 通常）
       if (a.category === "site" && b.category === "general") return -1;
       if (a.category === "general" && b.category === "site") return 1;
-      return 0;
+
+      // 同じカテゴリ内では優先度でソート（小さいほど優先度が高い）
+      const priorityA = a.priority ?? Number.MAX_VALUE;
+      const priorityB = b.priority ?? Number.MAX_VALUE;
+      return priorityA - priorityB;
     });
 
     const pageUrl = downloadPageUrlMap.get(item.id) || null;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export interface Rule {
   overrideFilename?: boolean; // ファイル名を上書きするかどうか
   rename?: boolean; // リネーム機能を使用するかどうか
   renameFilename?: string; // リネーム時の新しいファイル名
+  priority?: number; // カテゴリ内での優先順位（小さいほど優先度が高い）
 }
 
 /**


### PR DESCRIPTION
sortable.jsを使ったドラッグ&ドロップでルールの優先度を直感的に並び替えられるようにした

仕様

- ルールはカテゴリ（サイト別/通常）ごとに分類
- 優先度は小さい値ほど高優先（1が最高優先度）
- 並び替えモードはトグル可能（UI領域を節約）
- 変更は自動的にストレージに保存

Closes #6